### PR TITLE
Estrutura de fila

### DIFF
--- a/backend/app/services/queue_service.py
+++ b/backend/app/services/queue_service.py
@@ -80,7 +80,7 @@ class QueueService:
             "Ingresso": ticket,
             "unit_id": payload.unit_id,
             "person_name": payload.person_name,
-            "Prioridade": payload.priority,
+            "priority": payload.priority,
             "categoria": payload.category,
             "status": "esperando",
             "created_at": now_iso,

--- a/backend/app/services/queue_service.py
+++ b/backend/app/services/queue_service.py
@@ -1,7 +1,8 @@
+from datetime import datetime, timezone
 from fastapi import Depends
 
 from app.core.config import Settings, get_settings
-from app.core.exceptions import FeatureNotImplementedError
+from app.core.exceptions import FeatureNotImplementedError, AppException
 from app.repositories.queue_repository import QueueRepository, get_queue_repository
 from app.schemas.position import PositionSnapshotData
 from app.schemas.queue import (
@@ -14,53 +15,48 @@ from app.schemas.queue import (
     QueueSnapshotData,
 )
 
-
 class QueueService:
     def __init__(self, queue_repository: QueueRepository, settings: Settings) -> None:
         self.queue_repository = queue_repository
         self.api_prefix = settings.api_prefix
 
-    def create_entry(self, payload: QueueEntryCreateRequest) -> QueueEntryCreatedResult:
-        raise FeatureNotImplementedError(
-            "A criação de entradas da fila será implementada futuramente "
-        )
+    # --- Helpers de Contexto e Validação (Novos) ---
 
-    def call_next(self, payload: QueueActionRequest) -> QueueActionResult:
-        raise FeatureNotImplementedError(
-            "A chamada da próxima senha será implementada futuramente "
-        )
+    def _now(self) -> datetime:
+        """Retorna o timestamp atual em UTC para consistência do banco."""
+        return datetime.now(timezone.utc)
 
-    def finish_current(self, payload: QueueActionRequest) -> QueueActionResult:
-        raise FeatureNotImplementedError(
-            "A finalização do atendimento atual será implementada futuramente "
-        )
+    def _require_entry(self, token: str) -> dict:
+        """Busca uma entrada por token e lança AppException se não existir."""
+        entry = self.queue_repository.fetch_by_token(token)
+        
+        if not entry:
+            # Respeitando a assinatura: message, *, status_code, code
+            raise AppException(
+                message=f"A entrada com o token '{token}' não foi encontrada.",
+                status_code=404,
+                code="ENTRY_NOT_FOUND"
+            )
+        return entry
 
-    def get_queue_snapshot(self, unit_id: str) -> QueueSnapshotData:
-        waiting_entries = self.queue_repository.fetch_waiting_entries(unit_id)
-        current_entry = self.queue_repository.fetch_current_called_entry(unit_id)
-        last_called_entry = self.queue_repository.fetch_last_called_entry(unit_id)
+    def _build_entry_data(self, payload: QueueEntryCreateRequest, token: str, ticket: str) -> dict:
+        """Constrói o dicionário completo para persistência no Supabase."""
+        now_iso = self._now().isoformat()
+        return {
+            "token": token,
+            "ticket": ticket,
+            "unit_id": payload.unit_id,
+            "person_name": payload.person_name,
+            "priority": payload.priority,
+            "category": payload.category,
+            "status": "waiting",
+            "created_at": now_iso,
+            "updated_at": now_iso,
+        }
 
-        return QueueSnapshotData(
-            unit_id=unit_id,
-            current_ticket=current_entry["ticket"] if current_entry else None,
-            current_entry=self._build_current_entry_data(current_entry)
-            if current_entry
-            else None,
-            last_called=last_called_entry["ticket"] if last_called_entry else None,
-            waiting_count=len(waiting_entries),
-            queue=[self._build_entry_summary(entry) for entry in waiting_entries],
-        )
+    # --- Builders Ajustados (Removido @staticmethod) ---
 
-    def get_position_snapshot(self, token: str) -> PositionSnapshotData:
-        raise FeatureNotImplementedError(
-            "A consulta detalhada da posição será implementada futuramente "
-        )
-
-    def try_get_position_snapshot(self, token: str) -> PositionSnapshotData | None:
-        return None
-
-    @staticmethod
-    def _build_entry_summary(entry: dict) -> QueueEntrySummary:
+    def _build_entry_summary(self, entry: dict) -> QueueEntrySummary:
         return QueueEntrySummary(
             ticket=entry["ticket"],
             person_name=entry["person_name"],
@@ -69,8 +65,7 @@ class QueueService:
             status=entry["status"],
         )
 
-    @staticmethod
-    def _build_current_entry_data(entry: dict) -> CurrentQueueEntryData:
+    def _build_current_entry_data(self, entry: dict) -> CurrentQueueEntryData:
         return CurrentQueueEntryData(
             ticket=entry["ticket"],
             person_name=entry["person_name"],
@@ -80,6 +75,36 @@ class QueueService:
             called_at=entry.get("called_at"),
         )
 
+    # --- Métodos de Negócio ---
+
+    def create_entry(self, payload: QueueEntryCreateRequest) -> QueueEntryCreatedResult:
+        raise FeatureNotImplementedError("A criação de entradas será implementada futuramente.")
+
+    def call_next(self, payload: QueueActionRequest) -> QueueActionResult:
+        raise FeatureNotImplementedError("A chamada da próxima senha será implementada futuramente.")
+
+    def finish_current(self, payload: QueueActionRequest) -> QueueActionResult:
+        raise FeatureNotImplementedError("A finalização do atendimento será implementada futuramente.")
+
+    def get_queue_snapshot(self, unit_id: str) -> QueueSnapshotData:
+        waiting_entries = self.queue_repository.fetch_waiting_entries(unit_id)
+        current_entry = self.queue_repository.fetch_current_called_entry(unit_id)
+        last_called_entry = self.queue_repository.fetch_last_called_entry(unit_id)
+
+        return QueueSnapshotData(
+            unit_id=unit_id,
+            current_ticket=current_entry["ticket"] if current_entry else None,
+            current_entry=self._build_current_entry_data(current_entry) if current_entry else None,
+            last_called=last_called_entry["ticket"] if last_called_entry else None,
+            waiting_count=len(waiting_entries),
+            queue=[self._build_entry_summary(entry) for entry in waiting_entries],
+        )
+
+    def get_position_snapshot(self, token: str) -> PositionSnapshotData:
+        raise FeatureNotImplementedError("A consulta da posição será implementada futuramente.")
+
+    def try_get_position_snapshot(self, token: str) -> PositionSnapshotData | None:
+        return None
 
 def get_queue_service(
     queue_repository: QueueRepository = Depends(get_queue_repository),

--- a/backend/app/services/queue_service.py
+++ b/backend/app/services/queue_service.py
@@ -20,71 +20,14 @@ class QueueService:
         self.queue_repository = queue_repository
         self.api_prefix = settings.api_prefix
 
-    # --- Helpers de Contexto e Validação (Novos) ---
-
-    def _now(self) -> datetime:
-        """Retorna o timestamp atual em UTC para consistência do banco."""
-        return datetime.now(timezone.utc)
-
-    def _require_entry(self, token: str) -> dict:
-        """Busca uma entrada por token e lança AppException se não existir."""
-        entry = self.queue_repository.fetch_by_token(token)
-        
-        if not entry:
-            # Respeitando a assinatura: message, *, status_code, code
-            raise AppException(
-                message=f"A entrada com o token '{token}' não foi encontrada.",
-                status_code=404,
-                code="ENTRY_NOT_FOUND"
-            )
-        return entry
-
-    def _build_entry_data(self, payload: QueueEntryCreateRequest, token: str, ticket: str) -> dict:
-        """Constrói o dicionário completo para persistência no Supabase."""
-        now_iso = self._now().isoformat()
-        return {
-            "token": token,
-            "ticket": ticket,
-            "unit_id": payload.unit_id,
-            "person_name": payload.person_name,
-            "priority": payload.priority,
-            "category": payload.category,
-            "status": "waiting",
-            "created_at": now_iso,
-            "updated_at": now_iso,
-        }
-
-    # --- Builders Ajustados (Removido @staticmethod) ---
-
-    def _build_entry_summary(self, entry: dict) -> QueueEntrySummary:
-        return QueueEntrySummary(
-            ticket=entry["ticket"],
-            person_name=entry["person_name"],
-            priority=entry["priority"],
-            category=entry.get("category"),
-            status=entry["status"],
-        )
-
-    def _build_current_entry_data(self, entry: dict) -> CurrentQueueEntryData:
-        return CurrentQueueEntryData(
-            ticket=entry["ticket"],
-            person_name=entry["person_name"],
-            priority=entry["priority"],
-            category=entry.get("category"),
-            status=entry["status"],
-            called_at=entry.get("called_at"),
-        )
-
-    # --- Métodos de Negócio ---
-
     def create_entry(self, payload: QueueEntryCreateRequest) -> QueueEntryCreatedResult:
-        raise FeatureNotImplementedError("A criação de entradas será implementada futuramente.")
+        raise FeatureNotImplementedError()
 
     def call_next(self, payload: QueueActionRequest) -> QueueActionResult:
-        raise FeatureNotImplementedError("A chamada da próxima senha será implementada futuramente.")
+        raise FeatureNotImplementedError()
 
     def finish_current(self, payload: QueueActionRequest) -> QueueActionResult:
-        raise FeatureNotImplementedError("A finalização do atendimento será implementada futuramente.")
+        raise FeatureNotImplementedError()
 
     def get_queue_snapshot(self, unit_id: str) -> QueueSnapshotData:
         waiting_entries = self.queue_repository.fetch_waiting_entries(unit_id)
@@ -94,17 +37,78 @@ class QueueService:
         return QueueSnapshotData(
             unit_id=unit_id,
             current_ticket=current_entry["ticket"] if current_entry else None,
-            current_entry=self._build_current_entry_data(current_entry) if current_entry else None,
+            current_entry=self._build_current_entry_data(current_entry)
+            if current_entry
+            else None,
             last_called=last_called_entry["ticket"] if last_called_entry else None,
             waiting_count=len(waiting_entries),
             queue=[self._build_entry_summary(entry) for entry in waiting_entries],
         )
 
     def get_position_snapshot(self, token: str) -> PositionSnapshotData:
-        raise FeatureNotImplementedError("A consulta da posição será implementada futuramente.")
+        self._require_entry(token)
+        raise FeatureNotImplementedError()
 
     def try_get_position_snapshot(self, token: str) -> PositionSnapshotData | None:
         return None
+
+    def _now(self) -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    def _require_entry(self, token: str) -> dict:
+        entrada = self.queue_repository.fetch_queue_entry_by_token(token)
+        
+        if not entrada:
+            raise AppException(
+                message="Token de posição não encontrado.",
+                status_code=404,
+                code="POSITION_NOT_FOUND"
+            )
+        return entrada
+
+    def _build_queue_entry_record(
+        self, 
+        payload: QueueEntryCreateRequest, 
+        qr_token: str, 
+        ticket: str, 
+        ticket_sequence: int
+    ) -> dict:
+        now_iso = self._now()
+        return {
+            "qr_token": qr_token,
+            "ticket_sequence": ticket_sequence,
+            "Ingresso": ticket,
+            "unit_id": payload.unit_id,
+            "person_name": payload.person_name,
+            "Prioridade": payload.priority,
+            "categoria": payload.category,
+            "status": "esperando",
+            "created_at": now_iso,
+            "updated_at": now_iso,
+            "called_at": "Nenhuma",
+            "finished_at": "Nenhum",
+        }
+
+    @staticmethod
+    def _build_entry_summary(entry: dict) -> QueueEntrySummary:
+        return QueueEntrySummary(
+            ticket=entry["ticket"],
+            person_name=entry["person_name"],
+            priority=entry["priority"],
+            category=entry.get("category"),
+            status=entry["status"],
+        )
+
+    @staticmethod
+    def _build_current_entry_data(entry: dict) -> CurrentQueueEntryData:
+        return CurrentQueueEntryData(
+            ticket=entry["ticket"],
+            person_name=entry["person_name"],
+            priority=entry["priority"],
+            category=entry.get("category"),
+            status=entry["status"],
+            called_at=entry.get("called_at"),
+        )
 
 def get_queue_service(
     queue_repository: QueueRepository = Depends(get_queue_repository),


### PR DESCRIPTION
## 🧾 Resumo

Este PR entrega a base estrutural (helpers e validações) do QueueService, garantindo que a lógica de negócio do gerenciador de filas tenha suporte para timestamps consistentes, tratamento de erros centralizado e formatação de dados para o Supabase.

🏷️ Tipo de alteração

## 🏷️ Tipo de alteracao

Marque as opcoes aplicaveis:

- [X] ✨ feat (nova funcionalidade)
- [ ] 🐛 fix (correcao de bug)
- [ ] ♻️ refactor (melhoria sem alterar comportamento)
- [ ] 📝 docs (documentacao)
- [X] ✅ test (testes)
- [ ] 🔧 chore (tarefa de manutencao)

## 🔍 O que foi alterado

Liste os principais pontos:

- Helper _now(): Implementado para gerar timestamps em UTC (padrão ISO 8601), evitando conflitos de fuso horário no banco de dados.
- Helper _require_entry(): Centralização da validação de existência de registros na fila, disparando AppException (404) de forma padronizada.
- Builder _build_entry_data(): Método interno para mapear objetos de domínio para o formato de persistência exigido pelo repositório/Supabase.

## 🧪 Como testar

Descreva os passos para validar este PR localmente.

1. Navegue até a pasta do backend: cd backend
2. Certifique-se de ter as dependências instaladas: pip install fastapi pydantic-settings supabase
3. Execute o teste de fumaça via terminal: 
$env:PYTHONPATH = "."; python -c "from app.services.queue_service import QueueService; print('✅ Sucesso: O QueueService e as Exceptions foram carregados corretamente!')"

## 📸 Evidencias

Inclua prints, gifs ou logs relevantes (quando aplicavel).

## ⚠️ Impactos e riscos

- Impacta backend: [X] Sim [ ] Nao
- Impacta frontend: [ ] Sim [X] Nao
- Impacta banco de dados: [ ] Sim [X] Nao
- Quebra compatibilidade: [ ] Sim [X] Nao

Se marcou "Sim" em algum item, descreva os impactos:

## 🔗 Issue relacionada

- Closes #
- Relacionada a #

## ✅ Checklist

- [X] 👀 Li e revisei meu proprio codigo
- [ ] 📚 Atualizei a documentacao (quando necessario)
- [X] 🧪 Testei as alteracoes localmente
- [X] 🔐 Nao inclui segredos ou dados sensiveis
- [X] 🎯 Mantive o escopo do PR objetivo
